### PR TITLE
Clear args.monitor_port usage

### DIFF
--- a/lansound
+++ b/lansound
@@ -550,7 +550,7 @@ def main():
         sys.exit(0)
 
     app = LansoundClient(args.host, args.port, args.latency, args.idle_timeout,
-        args.auto_enable, args.ipv4, args.monitor_port, args.verbose)
+        args.auto_enable, args.ipv4, None, args.verbose)
     app.run()
 
 if __name__ == '__main__':


### PR DESCRIPTION
I get this error when I run the `lansound` client on Python 3.7.5 / Debian testing.

```bash
$ ./lansound
Traceback (most recent call last):
  File "./lansound", line 566, in <module>
    main()
  File "./lansound", line 553, in main
    args.auto_enable, args.ipv4, args.monitor_port, args.verbose)
AttributeError: 'Namespace' object has no attribute 'monitor_port'
```

It looks like the definition of the `monitor_port` argument is commented out, but the code still tries to access it in one place. Replacing this with `None` makes the problem go away.